### PR TITLE
Filter and Data Check Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ The Sample App can be hosted locally, or on Heroku or some other hosting service
 ### Providing Media for the Sample App to use
 
 1. Open your Dropbox that you used to login in the Media Library.
-2. There should be a folder called Apps and inside that a folder with the name of the Dropbox App you created. Place all of your media that you want the app to display in that folder. Videos and GIFs are currently not supported.
+2. There should be a folder called Apps and inside that a folder with the name of the Dropbox App you created. Place all of your media that you want the app to display in that folder. For pictures, JPG format should be used. Videos and GIFs are currently not supported.
+3. You will have to wait for Dropbox to add media_info to the file before it appears in the Hoostsuite content library, this can take some time.
 
 ### Configuring your OAuth 2 Dev Access Token
 

--- a/index.js
+++ b/index.js
@@ -203,7 +203,12 @@ var getItemsWithFilter = (folderName = '', authHeader = '', query = '', mediaTyp
       // filter for query
       .filter(item => {
         return item.name.toLowerCase().includes(query.toLowerCase());
+      })
+      // check if it has media_info
+      .filter(item => {
+        return item.media_info;
       });
+
       var promises = [];
       compatibleFiles.forEach(file => {
         promises.push(getDropboxDirectUrl(file.id, authHeader));
@@ -224,11 +229,18 @@ var getItemsWithFilter = (folderName = '', authHeader = '', query = '', mediaTyp
             return file.id === item.id;
           });
           const fileData = Object.assign({}, ...filteredData);
-          var media = new Media(file.media_info.metadata.dimensions.height, file.media_info.metadata.dimensions.width, fileData.sharedLink, file.name);
+
+          var media = new Media(
+            (file.media_info) ? file.media_info.metadata.dimensions.height : 0,
+            (file.media_info) ? file.media_info.metadata.dimensions.width : 0,
+            fileData.sharedLink,
+            file.name
+          );
           media.id = file.id;
           media.original.sizeInBytes = file.size;
           media.thumbnail.url = 'data:image/jpeg;base64, ' + fileData.thumbnail;
           return media;
+
         }));
         // body.cursor is the next cursor, cursor is the current cursor
         var metadata = new Metadata(body.cursor, cursor);


### PR DESCRIPTION
Images without media_info will not appear.

Double check for dimensions added, set to 0 if they don't exist.
(images load in Hootsuite but have messed up aspect ratio)

Readme updated for change.